### PR TITLE
Added functionality to choose whether to print status/clicks or not

### DIFF
--- a/mesa_viz_tornado/ModularVisualization.py
+++ b/mesa_viz_tornado/ModularVisualization.py
@@ -262,6 +262,7 @@ class ModularServer(tornado.web.Application):
         name="Mesa Model",
         model_params=None,
         port=None,
+        verbose=True
     ):
         """
         Args:
@@ -277,7 +278,7 @@ class ModularServer(tornado.web.Application):
             model_params: A dict of model parameters
         """
 
-        self.verbose = True
+        self.verbose = verbose
         self.max_steps = 100000
 
         if port is not None:


### PR DESCRIPTION
Issue: Currently it is not possible to choose whether or not to print status/changes made on the server. When the model is run for many steps, it makes the terminal difficult to use/see

![image](https://github.com/projectmesa/mesa-viz-tornado/assets/72234861/06c34dae-5b2b-41c9-8b35-53a751c2151f)

In the ModularVisualization.py file, while the functionality of verbose for class ModularServer is implemented it is not active and permanently set to True. 


The small change implemented sets the default for printing to True, but also allows the user to change it to False if they prefer to do so. This is done by simply adding another optional input parameter with default True. 