### PR TITLE
Changes to modular_template.html's navbar

### DIFF
--- a/mesa_viz_tornado/templates/modular_template.html
+++ b/mesa_viz_tornado/templates/modular_template.html
@@ -20,7 +20,7 @@
 <body>
 
     <!-- Navbar -->
-    <nav class="navbar navbar-dark bg-dark navbar-static-top navbar-expand-lg mb-3">
+    <nav class="navbar navbar-dark bg-dark sticky-top navbar-expand-lg mb-3">
         <div class="container">
             <button type="button" class="navbar-toggler collapsed" data-bs-toggle="collapse" data-bs-target="#navbar" aria-expanded="false" aria-controls="navbar">
                 <span class="visually-hidden">Toggle navigation</span>
@@ -37,11 +37,11 @@
                     </li>
                 </ul>
                 <ul class="nav navbar-nav ms-auto">
-                    <li id="play-pause" class="nav-item"><a href="#" class="nav-link">Start</a>
+                    <li id="play-pause" class="nav-item"><button class="btn nav-link"">Start</button>
                     </li>
-                    <li id="step" class="nav-item"><a href="#" class="nav-link">Step</a>
+                    <li id="step" class="nav-item"><button class="btn nav-link">Step</button>
                     </li>
-                    <li id="reset" class="nav-item"><a href="#" class="nav-link">Reset</a>
+                    <li id="reset" class="nav-item"><button class="btn nav-link">Reset</button>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Added a sticky attribute to the navbar so if the canvas is bigger than the screen, you can push the actions in the whole page.
Also the actions have been replaced to hyperlinks(a element) to button in order to avoid reloading the page at each press and not bring the page at the top after each action.